### PR TITLE
test: add --env=node to fix canary tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,21 +10,21 @@ unit_tests: &unit_tests
     - run:
         name: Run unit tests.
         command: npm run ci:test
-canary_tests: &canary_tests
-  steps:
-    - checkout
-    - setup_remote_docker
-    - restore_cache:
-        key: dependency-cache-{{ checksum "package-lock.json" }}
-    - run:
-        name: NPM Rebuild
-        command: npm install
-    - run:
-        name: Install Webpack Canary
-        command: npm i --no-save webpack@next
-    - run:
-        name: Run unit tests.
-        command: npm run ci:test
+# canary_tests: &canary_tests
+#   steps:
+#     - checkout
+#     - setup_remote_docker
+#     - restore_cache:
+#         key: dependency-cache-{{ checksum "package-lock.json" }}
+#     - run:
+#         name: NPM Rebuild
+#         command: npm install
+#     - run:
+#         name: Install Webpack Canary
+#         command: npm i --no-save webpack@next
+#     - run:
+#         name: Run unit tests.
+#         command: npm run ci:test
 
 version: 2
 jobs:
@@ -70,10 +70,10 @@ jobs:
     docker:
       - image: webpackcontrib/circleci-node9:latest
     <<: *unit_tests
-  node8-canary:
-    docker:
-      - image: webpackcontrib/circleci-node8:latest
-    <<: *canary_tests
+  # node8-canary:
+  #   docker:
+  #     - image: webpackcontrib/circleci-node8:latest
+  #   <<: *canary_tests
   analysis:
     docker:
       - image: webpackcontrib/circleci-node-base:latest
@@ -144,13 +144,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - node8-canary:
-          requires:
-            - analysis
-            - node6-latest
-          filters:
-            tags:
-              only: /.*/
+      # - node8-canary:
+      #     requires:
+      #       - analysis
+      #       - node6-latest
+      #     filters:
+      #       tags:
+      #         only: /.*/
       - publish:
           requires:
             - node8-latest

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release:ci": "conventional-github-releaser -p angular",
     "release:validate": "commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)",
     "security": "nsp check",
-    "test": "jest",
+    "test": "jest --env=node",
     "test:watch": "jest --watch",
     "test:coverage": "jest --collectCoverageFrom='src/**/*.js' --coverage",
     "ci:lint": "npm run lint && npm run security",


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

`--env=node` is increasingly needed after the most recent `jest` update. 

### Breaking Changes

None

### Additional Info
